### PR TITLE
Handle overlapping pump cycle requests by user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2018.10.26
+----------
+- Abort current pump operation if user initiates a new one
+- User can terminate current pump routine, but not modify it   
+- Only read pyqmix.config during startup
+
 2018.10.21
 ----------
 - Remove superfluous files

--- a/pyqmix_backend/app.py
+++ b/pyqmix_backend/app.py
@@ -116,6 +116,9 @@ class InitiateOrDisconnectPumps(Resource):
 
     def get(self):
 
+        # TESTING
+        print('TEST: is the config backend set up: ' + config.read_config()['qmix_config_dir'])
+
         # Initiate test scenario
         session_paramters['get_pumps_states_call_count'] +=1
 
@@ -167,6 +170,8 @@ class Pumps(Resource):
     def put(self, pump_id):
         payload = request.json
         action = payload['action']
+
+        print('action: ' + action)
 
         if action == 'referenceMove':
             pump_reference_move(pump_id)

--- a/pyqmix_backend/app.py
+++ b/pyqmix_backend/app.py
@@ -94,11 +94,14 @@ class SetUpConfig(Resource):
 
     def get(self):
         # Return a list of available config-dirs and send to frontend
-
         list_of_available_configurations = config.get_available_qmix_configs()
         list_of_available_syringe_sizes = list(syringes.keys())
 
-        setup_dict = {'available_configs': list_of_available_configurations,
+        # Return status of pump-setup
+        config_setup = is_config_set_up()
+
+        setup_dict = {'is_config_set_up': config_setup,
+                      'available_configs': list_of_available_configurations,
                       'available_syringes': list_of_available_syringe_sizes}
         return setup_dict
 
@@ -116,9 +119,6 @@ class InitiateOrDisconnectPumps(Resource):
 
     def get(self):
 
-        # TESTING
-        print('TEST: is the config backend set up: ' + config.read_config()['qmix_config_dir'])
-
         # Initiate test scenario
         session_paramters['get_pumps_states_call_count'] +=1
 
@@ -128,10 +128,7 @@ class InitiateOrDisconnectPumps(Resource):
             pump_state = get_pump_state(pump_id)
             pump_states.append(pump_state)
 
-        # Return status of pump-setup
-        config_setup = is_config_set_up()
-
-        system_state = {'config_setup': config_setup, 'pump_states': pump_states}
+        system_state = {'pump_states': pump_states}
 
         return system_state
 
@@ -189,7 +186,7 @@ class Pumps(Resource):
 def is_config_set_up():
 
     if app.config['test_session']:
-        if session_paramters['get_pumps_states_call_count'] < 2:
+        if session_paramters['get_pumps_states_call_count'] < 1:
             return False
         else:
             return True

--- a/pyqmix_backend/app.py
+++ b/pyqmix_backend/app.py
@@ -66,6 +66,10 @@ initiate_or_disconnect_pumps = api.model('Initiate pumps', {
                             required=True,
                             example=True)})
 
+stop_pumps = api.model('Stop pumps', {
+    'stop': Boolean(description='Stop pumps',
+                    required=True,
+                    example=True)})
 
 ## --- Endpoints --- ##
 
@@ -141,6 +145,14 @@ class InitiateOrDisconnectPumps(Resource):
             status = disconnect_pumps()
 
         return status
+
+@api.route('/api/stop')
+class StopPumps(Resource):
+
+    @api.expect(stop_pumps)
+    def put(self):
+        if not app.config['test_session']:
+            list(session_paramters['pumps'].values())[0].stop_all_pumps()
 
 
 @api.route('/api/pumps/<int:pump_id>')

--- a/pyqmix_frontend/src/App.js
+++ b/pyqmix_frontend/src/App.js
@@ -591,21 +591,28 @@ class PumpForm extends Component {
   // --- Send pump command to backend --- //
   sendCommmandToPumps = async (action, deepCopyState) => {
 
-    await this.waitForPumpingToFinish();
-    if (deepCopyState.requestCounter === this.state.requestCounter) {
-      for (let Index in deepCopyState.selectedPumps) {
-        let pumpID = deepCopyState.selectedPumps[Index];
-        let payload = await this.makePumpCommand(action, pumpID, deepCopyState);
+    // Send command if user did not disconnect pumps.
+    if (this.state.webConnectedToPumps) {
+      await this.waitForPumpingToFinish();
 
-        // Send information to pump-specific endpoint
-        fetch('/api/pumps/'+pumpID.toString(), {
-          method: 'put',
-          headers: {
-            'Accept': 'application/json, text/plain, */*',
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify(payload)
-        });
+      if (deepCopyState.requestCounter === this.state.requestCounter) {
+        for (let Index in deepCopyState.selectedPumps) {
+          let pumpID = deepCopyState.selectedPumps[Index];
+          let payload = await this.makePumpCommand(action, pumpID, deepCopyState);
+
+          // Send information to pump-specific endpoint if user has not
+          // disconnected pumps
+          if (this.state.webConnectedToPumps) {
+            fetch('/api/pumps/' + pumpID.toString(), {
+              method: 'put',
+              headers: {
+                'Accept': 'application/json, text/plain, */*',
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(payload)
+            });
+          }
+        }
       }
     }
   };

--- a/pyqmix_frontend/src/App.js
+++ b/pyqmix_frontend/src/App.js
@@ -5,8 +5,9 @@ import { Button, ButtonGroup, FormGroup, Input, Modal,
 // import logo from './snake.svg';
 import './App.css';
 
-// --- State --- //
 class PumpForm extends Component {
+
+  // --- State --- //
   state = {
 
     // System setup
@@ -46,14 +47,14 @@ class PumpForm extends Component {
     flowRate: {
       'fill': [],
       'empty': [],
-      'bubbleCycle': [],
+      'bubble': [],
       'rinse': [],
       'targetVolume': []
     },
     flowUnit: {
       'fill': "mL/s",
       'empty': "mL/s",
-      'bubbleCycle': "mL/s",
+      'bubble': "mL/s",
       'rinse': "mL/s",
       'targetVolume': "mL/s"
     },
@@ -91,6 +92,9 @@ class PumpForm extends Component {
 
   // --- Set single element of dictionary in state --- //
   handleStateChange = (stateKey, dictKey, value) => {
+
+    this.setState({activeSubform: dictKey});
+
     let tmpState = this.state[stateKey];
     tmpState[dictKey] = value;
     this.setState({[stateKey]: tmpState});
@@ -118,15 +122,19 @@ class PumpForm extends Component {
   };
 
   // --- Repetition --- //
-  getActiveRepetition = (activeSubform) => {
-    let repetitions = this.state.repetitions;
+  getActiveRepetition = (state) => {
+    let repetitions = state.repetitions;
+    let activeSubform = state.activeSubform;
     return repetitions[activeSubform];
   };
 
-  checkRepetitionInput = (activeForm) => {
-    let repetition = this.state.repetitions[activeForm];
+  checkRepetitionInput = () => {
+
+    const activeSubform = this.state.activeSubform;
+
+    let repetition = this.state.repetitions[activeSubform];
     if (repetition < 1) {
-      this.handleStateChange('repetitions', activeForm, 1);
+      this.handleStateChange('repetitions', activeSubform, 1);
     }
   };
 
@@ -146,33 +154,35 @@ class PumpForm extends Component {
     return factor
   };
 
-  getActiveTargetVolume = (activeSubform) => {
-    let targetVolume = this.state.targetVolume;
+  getActiveTargetVolume = (state) => {
+    let targetVolume = state.targetVolume;
+    let activeSubform = state.activeSubform;
     return targetVolume[activeSubform]
   };
 
-  getActiveVolumeUnit = (activeSubform) => {
-    let volumeUnit = this.state.volumeUnit;
+  getActiveVolumeUnit = (state) => {
+    let volumeUnit = state.volumeUnit;
+    let activeSubform = state.activeSubform;
     return volumeUnit[activeSubform]
   };
 
-  computeVolumeMilliLitres = (activeSubform) => {
-    let targetVolume = this.getActiveTargetVolume(activeSubform);
-    let volumeUnit = this.getActiveVolumeUnit(activeSubform);
+  computeVolumeMilliLitres = (state) => {
+    let targetVolume = this.getActiveTargetVolume(state);
+    let volumeUnit = this.getActiveVolumeUnit(state);
     let factor = this.computeConversionFactorOfVolumeUnitToMilliLitres(volumeUnit);
     return targetVolume * factor;
   };
 
-  computeMaximallyAllowedVolumeUnitAsSpecifiedInForm = (activeSubform) => {
+  computeMaximallyAllowedVolumeUnitAsSpecifiedInForm = () => {
     if (this.state.selectedPumps.length > 0) {
-      let maxAllowedVolume = this.computeSmallestSyringeVolumeMilliLitres(activeSubform);
-      let volumeUnit = this.getActiveVolumeUnit(activeSubform);
+      let maxAllowedVolume = this.computeSmallestSyringeVolumeMilliLitres();
+      let volumeUnit = this.getActiveVolumeUnit(this.state);
       let factor = this.computeConversionFactorOfVolumeUnitToMilliLitres(volumeUnit);
       return (maxAllowedVolume / factor);
     } else {return []}
   };
 
-  computeSmallestSyringeVolumeMilliLitres = (activeSubform) => {
+  computeSmallestSyringeVolumeMilliLitres = () => {
     // Syringe volume is always set to mL in this.state.pumps
     if (this.state.selectedPumps.length > 0) {
       let selectedPumps = this.state.pumps.filter( (e) => this.state.selectedPumps.includes(e.pump_id) );
@@ -182,13 +192,16 @@ class PumpForm extends Component {
     } else {return ""}
   };
 
-  checkTargetVolumeInput = (activeSubform) => {
-    if (this.computeSmallestSyringeVolumeMilliLitres(activeSubform) < this.computeVolumeMilliLitres(activeSubform)) {
+  checkTargetVolumeInput = () => {
+
+    const activeSubform = this.state.activeSubform;
+
+    if (this.computeSmallestSyringeVolumeMilliLitres() < this.computeVolumeMilliLitres(this.state)) {
       console.log('Maximum volume exceeded, setting flow rate to maximum allowed value');
-      let targetVolume = this.computeMaximallyAllowedVolumeUnitAsSpecifiedInForm(activeSubform);
+      let targetVolume = this.computeMaximallyAllowedVolumeUnitAsSpecifiedInForm();
       this.handleStateChange('targetVolume', activeSubform, targetVolume);
     }
-    if (this.computeVolumeMilliLitres(activeSubform) < 0) {
+    if (this.computeVolumeMilliLitres(this.state) < 0) {
       console.log('Volume cannot be negative. Setting target volume to zero.');
       this.handleStateChange('targetVolume', activeSubform, 0);
     }
@@ -196,6 +209,7 @@ class PumpForm extends Component {
 
   // --- Flow --- //
   computeConversionFactorOfFlowUnitToMilliLitres = (flowUnit) => {
+
     let factor;
     switch (flowUnit) {
       case "mL/s":
@@ -204,6 +218,7 @@ class PumpForm extends Component {
       case "cL/s":
         factor = 10;
         break;
+      case "mL/min":
         factor = 1/60;
         break;
       case "cL/min":
@@ -215,9 +230,12 @@ class PumpForm extends Component {
     return factor;
   };
 
-  computeFlowMilliLitresPerSecond = (activeSubform) => {
-    let flowRate = this.state.flowRate[activeSubform];
-    let factor = this.computeConversionFactorOfFlowUnitToMilliLitres(this.state.flowUnit[activeSubform]);
+  computeFlowMilliLitresPerSecond = (state) => {
+    let activeSubform = state.activeSubform;
+    let flowRate = state.flowRate[activeSubform];
+    let flowUnit = state.flowUnit[activeSubform];
+
+    let factor = this.computeConversionFactorOfFlowUnitToMilliLitres(flowUnit);
     return flowRate * factor;
   };
 
@@ -230,20 +248,25 @@ class PumpForm extends Component {
   };
 
   computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm = (activeSubform) => {
+
     if (this.state.selectedPumps.length > 0) {
       let maxAllowedFlow = this.computeMaximallyAllowedFlowRateMilliLitresPerSecond();
-      let factor = this.computeConversionFactorOfFlowUnitToMilliLitres(this.state.flowUnit[activeSubform]);
+      let flowUnit = this.state.flowUnit[activeSubform];
+      let factor = this.computeConversionFactorOfFlowUnitToMilliLitres(flowUnit);
       return (maxAllowedFlow / factor).toString();
     } else {return ""}
   };
 
-  checkFlowRateInput = (activeSubform) => {
-    if (this.computeMaximallyAllowedFlowRateMilliLitresPerSecond() < this.computeFlowMilliLitresPerSecond(activeSubform)) {
+  checkFlowRateInput = () => {
+
+    const activeSubform = this.state.activeSubform;
+
+    if (this.computeMaximallyAllowedFlowRateMilliLitresPerSecond() < this.computeFlowMilliLitresPerSecond(this.state)) {
       console.log('Maximum flow rate exceeded, setting flow rate to maximum allowed value');
       let flowRate = parseFloat(this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm(activeSubform));
       this.handleStateChange('flowRate', activeSubform, flowRate);
     }
-    if (this.computeFlowMilliLitresPerSecond(activeSubform) < 0) {
+    if (this.computeFlowMilliLitresPerSecond(this.state) < 0) {
       console.log('Flow rate cannot be negative. Setting flow rate to zero.');
       this.handleStateChange('flowRate', activeSubform, 0);
     }
@@ -356,6 +379,12 @@ class PumpForm extends Component {
       }
     )};
 
+  deepCopy = (object) => {
+    const deepCopyString = JSON.stringify(object);
+    const deepCopyObject = JSON.parse(deepCopyString);
+    return deepCopyObject
+  };
+
   handlePumpOperation = async (subform) => {
 
     // Send request to backend to stop pumps
@@ -368,34 +397,33 @@ class PumpForm extends Component {
       body: JSON.stringify({'stop': true})
     });
 
-    // Update request counter
+    // Update request counter in state
     await this.asyncSetState({requestCounter: this.state.requestCounter+1});
-    console.log('subform initiated: ' + subform);
-    console.log('reference counter: ' + this.state.requestCounter.toString());
-    let requestCount = this.state.requestCounter;
 
-    // Update active Subform, and await the change!
+    // Update active subform in state
     await this.asyncSetState({activeSubform: subform});
 
+    // Deeo copy of this.state
+    const thisStateDeepCopy = this.deepCopy(this.state);
 
     switch (subform) {
       case "referenceMove":
-        this.handleReferenceMove(requestCount);
+        this.handleReferenceMove(thisStateDeepCopy);
         break;
       case "fill":
-        this.handleFill(requestCount);
+        this.handleFill(thisStateDeepCopy);
         break;
       case "empty":
-        this.handleEmpty(requestCount);
+        this.handleEmpty(thisStateDeepCopy);
         break;
-      case "bubbleCycle":
-        this.handleBubbleCycle(requestCount);
+      case "bubble":
+        this.handleBubbleCycle(thisStateDeepCopy);
         break;
       case "rinse":
-        this.handleRinse(requestCount);
+        this.handleRinse(thisStateDeepCopy);
         break;
       case "targetVolume":
-        this.handleTargetVolumeChange(requestCount);
+        this.handleTargetVolumeChange(thisStateDeepCopy);
         break;
       default:
         console.log('An unknown pump operation was initiated')
@@ -403,52 +431,52 @@ class PumpForm extends Component {
   };
 
   // --- Reference move --- //
-  handleReferenceMove = async (requestCount) => {
+  handleReferenceMove = async (deepCopyState) => {
 
     // To remove the modal
     this.toggle('referenceMove');
-    await this.sendCommmandToPumps('referenceMove', requestCount);
+    await this.sendCommmandToPumps('referenceMove', deepCopyState);
   };
 
   // --- Fill pumps --- //
-  handleFill = async (requestCount) => {
+  handleFill = async (deepCopyState) => {
 
     // To remove the modal
     this.toggle('fill');
 
     // Set pumps to fill level
-    await this.sendCommmandToPumps('fill', requestCount);
+    await this.sendCommmandToPumps('fill', deepCopyState);
 
     // Iterate over repetitions
     let repIndex;
-    for (repIndex = 1; repIndex < this.getActiveRepetition(this.state.activeSubform); repIndex++ ) {
+    for (repIndex = 1; repIndex < this.getActiveRepetition(deepCopyState); repIndex++ ) {
 
       // Empty syringes
-      await this.sendCommmandToPumps('empty', requestCount);
+      await this.sendCommmandToPumps('empty', deepCopyState);
 
       // Set pumps to fill level
-      await this.sendCommmandToPumps('fill', requestCount);
+      await this.sendCommmandToPumps('fill', deepCopyState);
     }
   };
 
   // --- Empty syringes --- //
-  handleEmpty = async (requestCount) => {
+  handleEmpty = async (deepCopyState) => {
 
     // To remove the modal
     this.toggle('empty');
 
     // Empty syringes
-    await this.sendCommmandToPumps('empty', requestCount);
+    await this.sendCommmandToPumps('empty', deepCopyState);
 
     // Iterate over repetitions
     let repIndex;
-    for (repIndex = 1; repIndex < this.getActiveRepetition(this.state.activeSubform); repIndex++ ) {
+    for (repIndex = 1; repIndex < this.getActiveRepetition(deepCopyState); repIndex++ ) {
 
       // Set pumps to fill level
-      await this.sendCommmandToPumps('fill', requestCount);
+      await this.sendCommmandToPumps('fill', deepCopyState);
 
       // Empty syringes
-      await this.sendCommmandToPumps('empty', requestCount);
+      await this.sendCommmandToPumps('empty', deepCopyState);
     }
   };
 
@@ -465,18 +493,18 @@ class PumpForm extends Component {
   };
 
   // --- Bubble cycle --- //
-  handleBubbleCycle = async (requestCount) => {
+  handleBubbleCycle = async (deepCopyState) => {
 
     // To remove the modal
     this.toggle('bubbleCycleStart');
 
     // Fill with stimulus
-    await this.sendCommmandToPumps('fillToOneThird', requestCount);
+    await this.sendCommmandToPumps('fillToOneThird', deepCopyState);
     await this.waitForPumpingToFinish();
 
     // Continue with the SECOND step of the bubble Cycle if user did not choose
     // another pump cycle meanwhile
-    if (requestCount === this.state.requestCounter) {
+    if (deepCopyState.requestCounter === this.state.requestCounter) {
 
       this.toggle('bubbleCycleMiddle');
 
@@ -489,21 +517,21 @@ class PumpForm extends Component {
         this.setState({userEnteredBubbleToggle: ""});
       } else if (this.state.userEnteredBubbleToggle === "continue") {
         this.setState({userEnteredBubbleToggle: ""});
-        this.handleBubbleCycleMiddle(requestCount)
+        this.handleBubbleCycleMiddle(deepCopyState)
       }
     }
   };
 
-  handleBubbleCycleMiddle = async (requestCount) => {
+  handleBubbleCycleMiddle = async (deepCopyState) => {
 
     // Fill in air
-    await this.sendCommmandToPumps('fillToTwoThird', requestCount);
+    await this.sendCommmandToPumps('fillToTwoThird', deepCopyState);
 
     // Empty syringes
-    await this.sendCommmandToPumps('empty', requestCount);
+    await this.sendCommmandToPumps('empty', deepCopyState);
     await this.waitForPumpingToFinish();
 
-    if (requestCount === this.state.requestCounter) {
+    if (deepCopyState.requestCounter === this.state.requestCounter) {
       this.toggle('bubbleCycleEnd');
 
       // Wait for user feedback and reset state
@@ -515,68 +543,60 @@ class PumpForm extends Component {
         this.setState({userEnteredBubbleToggle: ""});
       } else if (this.state.userEnteredBubbleToggle === "continue") {
         this.setState({userEnteredBubbleToggle: ""});
-        this.handleBubbleCycleEnd(requestCount)
+        this.handleBubbleCycleEnd(deepCopyState)
       }
     }
   };
 
-  handleBubbleCycleEnd = async (requestCount) => {
+  handleBubbleCycleEnd = async (deepCopyState) => {
 
     // Fill in stimulus
-    await this.sendCommmandToPumps('fill', requestCount);
+    await this.sendCommmandToPumps('fill', deepCopyState);
 
     // Fill in stimulus
-    await this.sendCommmandToPumps('empty', requestCount);
+    await this.sendCommmandToPumps('empty', deepCopyState);
 
     // Finish up by filling to level
-    await this.sendCommmandToPumps('fill', requestCount);
+    await this.sendCommmandToPumps('fill', deepCopyState);
   };
 
   // --- Rinse syringes --- //
-  handleRinse = async (requestCount) => {
+  handleRinse = async (deepCopyState) => {
 
     // To remove the modal
     this.toggle('rinse');
 
     // Iterate over repetitions
     let repIndex;
-    for (repIndex = 0; repIndex < this.getActiveRepetition(this.state.activeSubform); repIndex++ ) {
+    for (repIndex = 0; repIndex < this.getActiveRepetition(deepCopyState); repIndex++ ) {
 
       // Empty syringes
-      await this.sendCommmandToPumps('empty', requestCount);
+      await this.sendCommmandToPumps('empty', deepCopyState);
 
       // Fill syringes
-      await this.sendCommmandToPumps('fill', requestCount);
+      await this.sendCommmandToPumps('fill', deepCopyState);
 
       // Empty syringes
-      await this.sendCommmandToPumps('empty', requestCount);
+      await this.sendCommmandToPumps('empty', deepCopyState);
     }
   };
 
   // --- Set target volume of syringes --- //
-  handleTargetVolumeChange = async (requestCount) => {
-
-    // Set state
-    await this.asyncSetState({activeSubform: 'targetVolume'});
+  handleTargetVolumeChange = async (deepCopyState) => {
 
     // Fill to level
-    await this.sendCommmandToPumps('fillToLevel', requestCount);
+    await this.sendCommmandToPumps('fillToLevel', deepCopyState);
 
   };
 
   // --- Send pump command to backend --- //
-  sendCommmandToPumps = async (action, requestCount) => {
+  sendCommmandToPumps = async (action, deepCopyState) => {
 
-    console.log('send command to backend: ');
-    console.log(requestCount === this.state.requestCounter);
-    console.log('requestCount: ' + requestCount.toString() + ' state.requestCounter ' + this.state.requestCounter.toString());
     await this.waitForPumpingToFinish();
-    if (requestCount === this.state.requestCounter) {
-      let payload;
-      const activeSubform = this.state.activeSubform;
-      for (let Index in this.state.selectedPumps) {
-        let pumpID = this.state.selectedPumps[Index];
-        payload = await this.makePumpCommand(action, pumpID, activeSubform);
+    if (deepCopyState.requestCounter === this.state.requestCounter) {
+      for (let Index in deepCopyState.selectedPumps) {
+        let pumpID = deepCopyState.selectedPumps[Index];
+        let payload = await this.makePumpCommand(action, pumpID, deepCopyState);
 
         // Send information to pump-specific endpoint
         fetch('/api/pumps/'+pumpID.toString(), {
@@ -592,10 +612,10 @@ class PumpForm extends Component {
   };
 
   // --- Translate action to pump commands --- //
-  makePumpCommand = async (pumpAction, PumpName, activeSubform) => {
+  makePumpCommand = async (pumpAction, PumpName, deepCopyState) => {
 
-    let pumpCommand;
     let targetVolume;
+    let pumpCommand;
 
     if (pumpAction === 'referenceMove') {
       pumpCommand = {action: pumpAction};
@@ -603,20 +623,20 @@ class PumpForm extends Component {
 
       // If the command is fillToLevel, empty, or fill
       if (pumpAction === 'fillToLevel') {
-        targetVolume = this.computeVolumeMilliLitres(activeSubform);
+        targetVolume = this.computeVolumeMilliLitres(deepCopyState);
       } else if (pumpAction === 'empty') {
         targetVolume = 0;
       } else if (pumpAction === 'fill') {
-        targetVolume = this.state.pumps[PumpName].syringe_volume
+        targetVolume = deepCopyState.pumps[PumpName].syringe_volume
       } else if (pumpAction === 'fillToOneThird')  {
-        let pump = this.state.pumps.find(p => p.pump_id === PumpName);
+        let pump = deepCopyState.pumps.find(p => p.pump_id === PumpName);
         targetVolume = pump.syringe_volume * 1/3;
       } else if (pumpAction === 'fillToTwoThird') {
-        let pump = this.state.pumps.find(p => p.pump_id === PumpName);
+        let pump = deepCopyState.pumps.find(p => p.pump_id === PumpName);
         targetVolume = pump.syringe_volume * 2/3;
       }
 
-      let flowRate = this.computeFlowMilliLitresPerSecond(activeSubform);
+      let flowRate = this.computeFlowMilliLitresPerSecond(deepCopyState);
       pumpCommand = {
         'action': pumpAction,
         'params': {
@@ -701,7 +721,7 @@ class PumpForm extends Component {
                           key={config}
                           onClick={this.handleConfigNameChange}>
                           {config}
-                          </DropdownItem>
+                        </DropdownItem>
                       )}
                     </DropdownMenu>
                   </Dropdown>
@@ -719,7 +739,7 @@ class PumpForm extends Component {
                           key={config}
                           onClick={this.handleSyringeTypeChange}>
                           {config}
-                          </DropdownItem>
+                        </DropdownItem>
                       )}
                     </DropdownMenu>
                   </Dropdown>
@@ -729,8 +749,10 @@ class PumpForm extends Component {
             </ModalHeader>
 
             <ModalFooter>
-              <Button color="success" onClick={this.handleLocatingConfig}> Continue </Button>
-              <Button color="danger" onClick={() => this.toggle('locateConfigFiles')}> Cancel </Button>
+              <Button color="success"
+                      onClick={this.handleLocatingConfig}> Continue </Button>
+              <Button color="danger"
+                      onClick={() => this.toggle('locateConfigFiles')}> Cancel </Button>
             </ModalFooter>
           </Modal>
 
@@ -742,7 +764,8 @@ class PumpForm extends Component {
               connected already. Then try again.
             </ModalBody>
             <ModalFooter>
-              <Button color="success" onClick={() => this.toggle('noConfigOrDllFound')}> OK </Button>
+              <Button color="success"
+                      onClick={() => this.toggle('noConfigOrDllFound')}> OK </Button>
             </ModalFooter>
           </Modal>
         </div>
@@ -819,8 +842,12 @@ class PumpForm extends Component {
                       detach the spray head if repeating the fill procedure.
                     </ModalBody>
                     <ModalFooter>
-                      <Button color="success" onClick={() => this.handlePumpOperation('fill')}> Continue </Button>
-                      <Button color="danger" onClick={() => this.toggle('fill')}> Cancel </Button>
+                      <Button color="success"
+                              onClick={() => this.handlePumpOperation('fill')}> Continue
+                      </Button>
+                      <Button color="danger"
+                              onClick={() => this.toggle('fill')}> Cancel
+                      </Button>
                     </ModalFooter>
                   </Modal>
                 </div>
@@ -834,7 +861,7 @@ class PumpForm extends Component {
                          min="1"
                          placeholder="No. of repetitions."
                          onChange={(e) => this.handleStateChange('repetitions', 'fill', e.target.value)}
-                         onBlur={() => this.checkRepetitionInput('fill')}
+                         onBlur={() => this.checkRepetitionInput()}
                          required/>
                 </div>
 
@@ -850,12 +877,12 @@ class PumpForm extends Component {
                          max={this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm('fill')}
                          placeholder="Flow rate."
                          onChange={(e) => this.handleStateChange('flowRate', 'fill', e.target.value)}
-                         onBlur={() => this.checkFlowRateInput('fill')}
+                         onBlur={() => this.checkFlowRateInput()}
                          required/>
                   <Input type="select"
                          name="flowUnit"
                          defaultValue={this.state.flowUnit['fill']}
-                         onBlur={() => this.checkFlowRateInput('fill')}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowUnit', 'fill', e.target.value)}>
                     <option value="mL/s">mL/s</option>
                     <option value="mL/min">mL/min</option>
@@ -884,15 +911,18 @@ class PumpForm extends Component {
                   > Empty Cycle </Button>
                   <FormText>Empty & fill the syringe multiple times. Ends with an empty syringe.</FormText>
 
-                  <Modal isOpen={this.state.modal['empty']} className={this.props.className}>
+                  <Modal isOpen={this.state.modal['empty']}
+                         className={this.props.className}>
                     <ModalHeader>Empty</ModalHeader>
                     <ModalBody>
                       Remove the inlet tube from the stimulus reservoir and
                       detach the spray head from the mouthpiece.
                     </ModalBody>
                     <ModalFooter>
-                      <Button color="success" onClick={() => this.handlePumpOperation('empty')}> Continue </Button>
-                      <Button color="danger" onClick={() => this.toggle('empty')}> Cancel </Button>
+                      <Button color="success"
+                              onClick={() => this.handlePumpOperation('empty')}> Continue </Button>
+                      <Button color="danger"
+                              onClick={() => this.toggle('empty')}> Cancel </Button>
                     </ModalFooter>
                   </Modal>
                 </div>
@@ -905,7 +935,7 @@ class PumpForm extends Component {
                          min="1"
                          placeholder="No. of repetitions."
                          onChange={(e) => this.handleStateChange('repetitions', 'empty', e.target.value)}
-                         onBlur={() => this.checkRepetitionInput('empty')}
+                         onBlur={() => this.checkRepetitionInput()}
                          required/>
                 </div>
 
@@ -923,12 +953,12 @@ class PumpForm extends Component {
                          max={this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm('empty')}
                          placeholder="Flow rate."
                          onChange={(e) => this.handleStateChange('flowRate', 'empty', e.target.value)}
-                         onBlur={() => this.checkFlowRateInput('empty')}
+                         onBlur={() => this.checkFlowRateInput()}
                          required/>
                   <Input type="select"
                          name="flowUnit"
                          defaultValue={this.state.flowUnit['empty']}
-                         onBlur={() => this.checkFlowRateInput('empty')}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowUnit', 'empty', e.target.value)}>
                     <option value="mL/s">mL/s</option>
                     <option value="mL/min">mL/min</option>
@@ -964,7 +994,7 @@ class PumpForm extends Component {
                     <ModalFooter>
                       <Button
                         color="success"
-                        onClick={() => this.handlePumpOperation('bubbleCycle')}> Continue </Button>
+                        onClick={() => this.handlePumpOperation('bubble')}> Continue </Button>
                       <Button
                         color="danger"
                         onClick={() => this.toggle('bubbleCycleStart')}> Cancel </Button>
@@ -1018,12 +1048,12 @@ class PumpForm extends Component {
                          max={this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm('bubble')}
                          placeholder="Flow rate."
                          onChange={(e) => this.handleStateChange('flowRate', 'bubble', e.target.value)}
-                         onBlur={() => this.checkFlowRateInput('bubble')}
+                         onBlur={() => this.checkFlowRateInput()}
                          required/>
                   <Input type="select"
                          name="flowUnit"
-                         defaultValue={this.state.flowUnit['bubble']}
-                         onBlur={() => this.checkFlowRateInput('bubble')}
+                         defaultValue={this.state.flowUnit['bubbleCycle']}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowUnit', 'bubble', e.target.value)}>
                     <option value="mL/s">mL/s</option>
                     <option value="mL/min">mL/min</option>
@@ -1034,7 +1064,7 @@ class PumpForm extends Component {
               </div>
             </FormGroup>
           </Form>
-          
+
           {/*RINSE FORM*/}
           <Form method="post"
                 onSubmit={(e) => {
@@ -1050,7 +1080,8 @@ class PumpForm extends Component {
                           disabled={this.state.selectedPumps.length === 0}
                   > Rinse Cycle </Button>
                   <FormText>Empty & fill the syringe multiple times. Ends with an empty syringe.</FormText>
-                  <Modal isOpen={this.state.modal['rinse']} className={this.props.className}>
+                  <Modal isOpen={this.state.modal['rinse']}
+                         className={this.props.className}>
                     <ModalHeader>Rinse</ModalHeader>
                     <ModalBody>
                       Insert the inlet tube into the rinsing fluid
@@ -1074,7 +1105,7 @@ class PumpForm extends Component {
                          min="1"
                          placeholder="No. of repetitions."
                          onChange={(e) => this.handleStateChange('repetitions', 'rinse', e.target.value)}
-                         onBlur={() => this.checkRepetitionInput('rinse')}
+                         onBlur={() => this.checkRepetitionInput()}
                          required/>
                 </div>
 
@@ -1091,13 +1122,13 @@ class PumpForm extends Component {
                          min="0"
                          max={this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm('rinse')}
                          placeholder="Flow rate."
-                         onBlur={() => this.checkFlowRateInput('rinse')}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowRate', 'rinse', e.target.value)}
                          required/>
                   <Input type="select"
                          name="flowUnit"
                          defaultValue={this.state.flowUnit['rinse']}
-                         onBlur={() => this.checkFlowRateInput('rinse')}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowUnit', 'rinse', e.target.value)}>
                     <option value="mL/s">mL/s</option>
                     <option value="mL/min">mL/min</option>
@@ -1139,12 +1170,12 @@ class PumpForm extends Component {
                          max={this.computeSmallestSyringeVolumeMilliLitres('targetVolume')}
                          placeholder="Target volume."
                          onChange={(e) => this.handleStateChange('targetVolume', 'targetVolume', e.target.value)}
-                         onBlur={() => this.checkTargetVolumeInput('targetVolume')}
+                         onBlur={() => this.checkTargetVolumeInput()}
                          required/>
                   <Input type="select"
                          name="flowUnit"
                          defaultValue={this.state.volumeUnit['targetVolume']}
-                         onBlur={() => this.checkTargetVolumeInput('targetVolume')}
+                         onBlur={() => this.checkTargetVolumeInput()}
                          onChange={(e) => this.handleStateChange('volumeUnit', 'targetVolume', e.target.value)}>
                     <option value="mL">mL</option>
                     <option value="cL">cL</option>
@@ -1162,12 +1193,12 @@ class PumpForm extends Component {
                          max={this.computeMaximallyAllowedFlowRateUnitAsSpecifiedInForm('targetVolume')}
                          placeholder="Flow rate."
                          onChange={(e) => this.handleStateChange('flowRate', 'targetVolume', e.target.value)}
-                         onBlur={() => this.checkFlowRateInput('targetVolume')}
+                         onBlur={() => this.checkFlowRateInput()}
                          required/>
                   <Input type="select"
                          name="flowUnit"
                          defaultValue={this.state.flowUnit['targetVolume']}
-                         onBlur={() => this.checkFlowRateInput('targetVolume')}
+                         onBlur={() => this.checkFlowRateInput()}
                          onChange={(e) => this.handleStateChange('flowUnit', 'targetVolume', e.target.value)}>
                     <option value="mL/s">mL/s</option>
                     <option value="mL/min">mL/min</option>
@@ -1197,7 +1228,7 @@ class App extends Component {
         {/*<p className="App-intro">*/}
         {/*</p>*/}
         <div className="entire-pump-form">
-        <PumpForm/>
+          <PumpForm/>
         </div>
       </div>
     );


### PR DESCRIPTION
- [x] I have updated `CHANGES.md`

The main updates are:
- Abort current pump operation if user initiates a new one
- User can terminate current pump routine, but not modify it   
- Only read pyqmix.config during startup

Closes #14 