### PR TITLE
RF: Temporarily disable display of pyqmix version number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,3 @@
-2018.11.05
-----------
-- Display pyqmix version on the web application
-
 2018.10.26
 ----------
 - Abort current pump operation if user initiates a new one

--- a/pyqmix_frontend/src/App.js
+++ b/pyqmix_frontend/src/App.js
@@ -1243,11 +1243,12 @@ class Outro extends Component {
   };
 
   render = () => {
-    return (
-      <p>
-        pyqmix version {this.state.pyqmixVersion}
-      </p>
-    )
+    return null;
+    // return (
+    //   <p>
+    //     pyqmix version {this.state.pyqmixVersion}
+    //   </p>
+    // )
   }
 }
 


### PR DESCRIPTION
Versioner does not seem to provide proper version number in standalone
created via pyinstaller.

- [x] I have updated `CHANGES.md`
