### PR TITLE
NF: Enable user to specify pump configuration directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   in their terminal after installation, which will fire up the backend and
   open the browser
 - Add versioneer
+- Enable user to specify pump configuration directory
 - Update to `react-scripts` 2.1.3
 
 2018.11.07


### PR DESCRIPTION
The default pump configuration directory remains:
`C:/Users/Public/Documents/QmixElements/Projects/default_project/Configurations/`,
but the user now has the option to specify a custom path each time the 'Detect Pumps'-button is pressed.

This commit resolves #34 and closes #35.

- [x] I have updated `CHANGES.md`
